### PR TITLE
small usability improvement

### DIFF
--- a/08 - vm 2/vmTranslator/CMakeLists.txt
+++ b/08 - vm 2/vmTranslator/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB sources src/*.cpp main.cpp)
+include_directories(include)
+add_executable(VMTranslator ${sources})

--- a/08 - vm 2/vmTranslator/main.cpp
+++ b/08 - vm 2/vmTranslator/main.cpp
@@ -6,7 +6,7 @@
 #include "FileHandler.h"
 
 using namespace std;
-
+/*
 int main(int argc, char** argv)
 {
 	bool verbose = false;
@@ -35,8 +35,8 @@ int main(int argc, char** argv)
 
 	return 0;
 }
+*/
 
-/*
 int main(int argc, char** argv)
 {
 	if (argc == 1) {
@@ -101,4 +101,4 @@ int main(int argc, char** argv)
 
 	return 0;
 }
-*/
+

--- a/08 - vm 2/vmTranslator/src/VmTranslator.cpp
+++ b/08 - vm 2/vmTranslator/src/VmTranslator.cpp
@@ -279,7 +279,7 @@ bool VmTranslator::translateOptimisedSequence(Parser& parser, CodeWriterOptimise
                 parser.advance();
                 int pointerIndex = parser.arg2();
 
-                cout << "HERE" << endl;
+                //cout << "HERE" << endl;
 
                 codeWriterOpt->writeSeqPushArgumentPopPointer(argIndex, pointerIndex);
                 vmCmdList.erase(vmCmdList.begin(), vmCmdList.begin() + 2);


### PR DESCRIPTION
Was looking for a size optimizing vmtranslator (mine generates >32k ROM files for some Hack programs) and I found yours. To save people the hassle, I suggest adding the CMakeLists.txt file. The you can quickly start rolling by
    cmake .
    make
in the vmtranslator folder.
Did you finish the JackCompiler too by the way? I think there is a lot of room for improvement (size or speed) in generating optimized VM code too.
Best regards.
Jan